### PR TITLE
Fixes typo in Widget - Cyanide.sublime-settings

### DIFF
--- a/Cyanide/Widget - Cyanide.sublime-settings
+++ b/Cyanide/Widget - Cyanide.sublime-settings
@@ -1,5 +1,5 @@
 {
-    "color_scheme": "Packages/Theme - Cyanide/Cyanide/Widget - cyanide.stTheme",
+    "color_scheme": "Packages/Theme - Cyanide/Cyanide/Widget - Cyanide.stTheme",
     "draw_shadows": false
 }
 


### PR DESCRIPTION
Type caused error every time sublime started
