### PR TITLE
Fix #27, defaulting to text/plain in *.tmLanguage include instruction.

### DIFF
--- a/Cyanide/file_types/Adobe Photoshop.tmLanguage
+++ b/Cyanide/file_types/Adobe Photoshop.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string></string>
+			<string>text/plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cyanide/file_types/Adobe Photoshop.tmLanguage
+++ b/Cyanide/file_types/Adobe Photoshop.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string>text/plain</string>
+			<string>text.plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cyanide/file_types/Git.tmLanguage
+++ b/Cyanide/file_types/Git.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string></string>
+			<string>text/plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cyanide/file_types/Git.tmLanguage
+++ b/Cyanide/file_types/Git.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string>text/plain</string>
+			<string>text.plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cyanide/file_types/font.tmLanguage
+++ b/Cyanide/file_types/font.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string></string>
+			<string>text/plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cyanide/file_types/font.tmLanguage
+++ b/Cyanide/file_types/font.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string>text/plain</string>
+			<string>text.plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cyanide/file_types/license.tmLanguage
+++ b/Cyanide/file_types/license.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string></string>
+			<string>text/plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Cyanide/file_types/license.tmLanguage
+++ b/Cyanide/file_types/license.tmLanguage
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>include</key>
-			<string>text/plain</string>
+			<string>text.plain</string>
 		</dict>
 	</array>
 	<key>scopeName</key>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -238,7 +238,7 @@ module.exports = function(grunt) {
         // Generate *.tmLanguage:
         data.languages.forEach(function(lang) {
             generating(lang.lang + '.tmLanguage');
-            lang.include = lang.scopes.length > 1 ? lang.scopes[0] : 'text/plain';
+            lang.include = lang.scopes.length > 1 ? lang.scopes[0] : 'text.plain';
             share('lang', lang);
             share('replace.languages.dest', fileTypesDir + lang.lang + '.tmLanguage');
             grunt.task.run('replace:languages');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -238,7 +238,7 @@ module.exports = function(grunt) {
         // Generate *.tmLanguage:
         data.languages.forEach(function(lang) {
             generating(lang.lang + '.tmLanguage');
-            lang.include = lang.scopes.length > 1 ? lang.scopes[0] : '';
+            lang.include = lang.scopes.length > 1 ? lang.scopes[0] : 'text/plain';
             share('lang', lang);
             share('replace.languages.dest', fileTypesDir + lang.lang + '.tmLanguage');
             grunt.task.run('replace:languages');

--- a/messages.json
+++ b/messages.json
@@ -4,6 +4,7 @@
     "2.0.0": "messages/2.0.0.md",
     "2.1.0": "messages/2.1.0.md",
     "2.2.0": "messages/2.2.0.md",
-    "2.3.0": "messages/2.3.0.md"
-    "2.3.5": "messages/2.3.5.md"
+    "2.3.0": "messages/2.3.0.md",
+    "2.3.5": "messages/2.3.5.md",
+    "2.3.6": "messages/2.3.6.md"
 }

--- a/messages/2.3.6.md
+++ b/messages/2.3.6.md
@@ -1,0 +1,9 @@
+Cyanide 2.3.6
+===============
+
++ Fix #27, defaulting to text/plain in *.tmLanguage include instruction.
+
+Thanks for downloading Cyanide Theme!
+Feel free to open an issue on Github if you have any problem with the theme.
+
+https://github.com/lefoy/cyanide-theme


### PR DESCRIPTION
See #27.

This should fix the issue by defaulting to `text/plain` for created languages that don't have more than 1 inherited scope. These currently are: Font, LICENSE, Git, Adobe Photoshop.

Recommended action:
+ Release as version `2.3.6`