### PR TITLE
fixed search path in quick menu for sublime text 3

### DIFF
--- a/Cyanide.sublime-theme
+++ b/Cyanide.sublime-theme
@@ -325,7 +325,7 @@
     },
     {
         "class": "quick_panel_path_label",
-        "fg": [130,130,130,0],
+        "fg": [130,130,130,255],
         "match_fg": [220,220,220],
         "selected_fg": [255,255,255],
         "selected_match_fg": [255,255,255]


### PR DESCRIPTION
Changed text color of path in quick menu, in newest sublime text 3 is that color unreadable.

issue #48